### PR TITLE
feat: Add destructive `merge_args!/3` function

### DIFF
--- a/lib/fixture_builder.ex
+++ b/lib/fixture_builder.ex
@@ -119,6 +119,7 @@ defmodule FixtureBuilder do
 
       @doc """
       Merges keys from `source` into `target` according to the defined `mapping`.
+      This function ignores the given keys in the `mapping` if these keys exists in `source`.
       """
       @spec merge_args(map(), FixtureBuilder.t() | map(), %{atom() => atom() | list()}) :: map()
       def merge_args(target, %FixtureBuilder{data: source}, mapping),
@@ -131,6 +132,20 @@ defmodule FixtureBuilder do
           else
             acc
           end
+        end)
+      end
+
+      @doc """
+      Merges keys from `source` into `target` according to the defined `mapping`.
+      It overrides any existing keys in `source`.
+      """
+      @spec merge_args!(map(), FixtureBuilder.t() | map(), %{atom() => atom() | list()}) :: map()
+      def merge_args!(target, %FixtureBuilder{data: source}, mapping),
+        do: merge_args!(target, source, mapping)
+
+      def merge_args!(target, source, mapping) do
+        Enum.reduce(mapping, target, fn {attr, path}, acc ->
+          Map.put(acc, attr, FixtureBuilder.Utils.get(source, path))
         end)
       end
     end

--- a/test/fixture_builder_test.exs
+++ b/test/fixture_builder_test.exs
@@ -26,6 +26,18 @@ defmodule FixtureBuilderTest do
     end
   end
 
+  describe "merge_args!()" do
+    test "merges correctly" do
+      fixtures =
+        Fixtures.fixtures([
+          put(:a, :custom_value, %{value: "hello modern world"})
+        ])
+
+      assert %{a: "hello modern world"} ==
+               Fixtures.merge_args!(%{a: "hello world"}, fixtures, %{a: [:a]})
+    end
+  end
+
   describe "fixtures()" do
     test "pass initial data" do
       assert %{hello: "world"} ==


### PR DESCRIPTION
Sometimes we want just to override the existing value under given keys. While `merge_args/3` is using `Map.has_key?` to put only new key-value pairs, the new `merge_args!/3` looks like a nice fit.